### PR TITLE
Fix rofi Flag for Using Fuzzy Matching

### DIFF
--- a/books-search/books-search.sh
+++ b/books-search/books-search.sh
@@ -11,7 +11,7 @@
 # Requirements:
 #   rofi
 # Description:
-#   Use rofi to search my books. 
+#   Use rofi to search my books.
 # Usage:
 #   books-search.sh
 # -----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ readarray -t F_ARRAY <<< "$(find "$BOOKS_DIR" -type f -name '*.pdf')"
 # key => book name
 # value => absolute path to the file
 # BOOKS['filename']='path'
-declare -A BOOKS 
+declare -A BOOKS
 
 # Add elements to BOOKS array
 get_books() {
@@ -49,10 +49,10 @@ gen_list(){
 
 main() {
   get_books
-  book=$( (gen_list) | rofi -dmenu -i -fuzzy -only-match -location 0 -p "Book > " )
+  book=$( (gen_list) | rofi -dmenu -i -matching fuzzy -only-match -location 0 -p "Book > " )
   xdg-open "${BOOKS[$book]}"
 }
 
-main 
+main
 
 exit 0

--- a/github-repos.sh
+++ b/github-repos.sh
@@ -11,10 +11,10 @@
 # Requirements:
 #   rofi, git
 # Description:
-#   Display all repositories connected with a GitHub user account in rofi and 
+#   Display all repositories connected with a GitHub user account in rofi and
 #   clone the selected repository.
 # Usage:
-#   github-repos.sh 
+#   github-repos.sh
 # -----------------------------------------------------------------------------
 # Script:
 
@@ -38,13 +38,13 @@ clone_repository(){
 # the repository name from the output with sed substitution
 all_my_repositories_short_name(){
   curl -s "https://api.github.com/users/$USER/repos?per_page=1000" | grep -o 'git@[^"]*' |\
-    sed "s/git@github.com:$USER\///g" 
+    sed "s/git@github.com:$USER\///g"
 }
 
-# Rofi dmenu 
+# Rofi dmenu
 rofi_dmenu(){
-  rofi -dmenu -fuzzy -only-match -location 0 -p "Select a repository > "\
-    -bg "#F8F8FF" -fg "#000000" -hlbg "#ECECEC" -hlfg "#0366d6"
+  rofi -dmenu -matching fuzzy -only-match -p "Select a repository > "\
+    -location 0 -bg "#F8F8FF" -fg "#000000" -hlbg "#ECECEC" -hlfg "#0366d6"
 }
 
 main(){

--- a/web-search.sh
+++ b/web-search.sh
@@ -11,7 +11,7 @@
 # Requirements:
 #   rofi
 # Description:
-#   Use rofi to search the web. 
+#   Use rofi to search the web.
 # Usage:
 #   web-search.sh
 # -----------------------------------------------------------------------------
@@ -50,17 +50,17 @@ gen_list() {
 
 main() {
   # Pass the list to rofi
-  platform=$( (gen_list) | rofi -dmenu -fuzzy -only-match -location 0 -p "Search > " )
+  platform=$( (gen_list) | rofi -dmenu -matching fuzzy -only-match -location 0 -p "Search > " )
 
-  query=$( (echo ) | rofi  -dmenu -fuzzy -location 0 -p "Query > " )
+  query=$( (echo ) | rofi  -dmenu -matching fuzzy -location 0 -p "Query > " )
   if [[ -n "$query" ]]; then
     url=${URLS[$platform]}$query
     xdg-open "$url"
-  else 
+  else
     rofi -show -e "No query provided."
   fi
 }
 
-main 
+main
 
 exit 0


### PR DESCRIPTION
I believe you meant to use the flag `-matching fuzzy` to do fuzzy finding on the results.

I also accidentally stripped all the trailing whitespace, but that doesn't change the functionality if you're fine with that.