### PR TITLE
glob does a better job at fuzzy finding files

### DIFF
--- a/books-search/books-search.sh
+++ b/books-search/books-search.sh
@@ -61,7 +61,7 @@ gen_list(){
 
 main() {
   get_books
-  book=$( (gen_list) | rofi -dmenu -i -matching fuzzy -no-custom -location 0 -p "Book > " )
+  book=$( (gen_list) | rofi -dmenu -i -matching glob -no-custom -location 0 -p "Book > " )
 
   if [ -n "$book" ]; then
     xdg-open "${BOOKS[$book]}"


### PR DESCRIPTION
Multiple file types can also be searched using the  `-o` flag in the `find` command, as for my case where I have both epub and pdf files in my books directory:
```bash
readarray -t F_ARRAY <<< "$(find "$BOOKS_DIR" -type f -name '*.epub' -o -name '*.pdf')"
```